### PR TITLE
fix: add connection cleanup to LLM clients to prevent container restarts

### DIFF
--- a/arshai/llms/azure.py
+++ b/arshai/llms/azure.py
@@ -35,6 +35,41 @@ class AzureClient(ILLM):
         # Initialize the client
         self._client = self._initialize_client()
     
+    def __del__(self):
+        """Cleanup connections when the client is destroyed."""
+        self.close()
+    
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    def close(self):
+        """Close the Azure OpenAI client and cleanup connections."""
+        try:
+            # Close the underlying httpx client if it exists
+            if hasattr(self._client, '_client') and hasattr(self._client._client, 'close'):
+                self._client._client.close()
+                self.logger.info("Closed Azure OpenAI httpx client")
+            elif hasattr(self._client, 'close'):
+                self._client.close()
+                self.logger.info("Closed Azure OpenAI client")
+        except Exception as e:
+            self.logger.warning(f"Error closing Azure OpenAI client: {e}")
+    
     def _initialize_client(self) -> Any:
         """
         Initialize the Azure OpenAI client with safe HTTP configuration.

--- a/arshai/llms/google_genai.py
+++ b/arshai/llms/google_genai.py
@@ -49,6 +49,49 @@ class GeminiClient(ILLM):
         
         # Initialize the client
         self._client = self._initialize_client()
+        self._http_client = None  # Track httpx client if using custom one
+    
+    def __del__(self):
+        """Cleanup connections when the client is destroyed."""
+        self.close()
+    
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    def close(self):
+        """Close the GenAI client and cleanup connections."""
+        try:
+            # Close the httpx client if we have one
+            if self._http_client is not None:
+                self._http_client.close()
+                self._http_client = None
+                self.logger.info("Closed custom httpx client for Gemini")
+            
+            # Try to close the GenAI client if it has a close method
+            if hasattr(self._client, 'close'):
+                self._client.close()
+                self.logger.info("Closed Gemini client")
+            elif hasattr(self._client, '_transport') and hasattr(self._client._transport, 'close'):
+                # Try to close underlying transport
+                self._client._transport.close()
+                self.logger.info("Closed Gemini client transport")
+        except Exception as e:
+            self.logger.warning(f"Error closing Gemini client: {e}")
     
     def _initialize_client(self) -> Any:
         """

--- a/arshai/llms/openai.py
+++ b/arshai/llms/openai.py
@@ -26,6 +26,41 @@ class OpenAIClient(ILLM):
         # Initialize the client
         self._client = self._initialize_client()
     
+    def __del__(self):
+        """Cleanup connections when the client is destroyed."""
+        self.close()
+    
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    def close(self):
+        """Close the OpenAI client and cleanup connections."""
+        try:
+            # Close the underlying httpx client if it exists
+            if hasattr(self._client, '_client') and hasattr(self._client._client, 'close'):
+                self._client._client.close()
+                self.logger.info("Closed OpenAI httpx client")
+            elif hasattr(self._client, 'close'):
+                self._client.close()
+                self.logger.info("Closed OpenAI client")
+        except Exception as e:
+            self.logger.warning(f"Error closing OpenAI client: {e}")
+    
     def _initialize_client(self) -> Any:
         """
         Initialize the OpenAI client with safe HTTP configuration and version compatibility.

--- a/arshai/llms/openrouter.py
+++ b/arshai/llms/openrouter.py
@@ -26,6 +26,41 @@ class OpenRouterClient(ILLM):
         # Initialize the client
         self._client = self._initialize_client()
     
+    def __del__(self):
+        """Cleanup connections when the client is destroyed."""
+        self.close()
+    
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit - cleanup connections."""
+        self.close()
+        return False
+    
+    def close(self):
+        """Close the OpenRouter client and cleanup connections."""
+        try:
+            # Close the underlying httpx client if it exists
+            if hasattr(self._client, '_client') and hasattr(self._client._client, 'close'):
+                self._client._client.close()
+                self.logger.info("Closed OpenRouter httpx client")
+            elif hasattr(self._client, 'close'):
+                self._client.close()
+                self.logger.info("Closed OpenRouter client")
+        except Exception as e:
+            self.logger.warning(f"Error closing OpenRouter client: {e}")
+    
     def _initialize_client(self) -> Any:
         """
         Initialize the OpenRouter client with safe HTTP configuration.


### PR DESCRIPTION
- Added close() method and context manager support to all LLM clients (OpenAI, Azure, OpenRouter, Gemini)
- Reduced connection pool limits to prevent exhaustion (max_connections: 200→50, keepalive: 100→20)
- Added automatic cleanup via __del__ for garbage collection
- Reduced keepalive expiry from 60s to 30s for faster idle connection cleanup

This fixes the issue where containers would hang and restart due to exhausted HTTP connection pools, particularly with Google's AI Platform requests getting stuck on receive_response_headers.