### PR TITLE
fix: resolve f-string syntax error in OpenAI client logging

### DIFF
--- a/arshai/llms/openai.py
+++ b/arshai/llms/openai.py
@@ -779,7 +779,7 @@ class OpenAIClient(BaseLLMClient):
                                     self.logger.debug(f"Skipping structure function {function_name} from progressive execution")
                                     continue
                                 
-                                self.logger.debug(f"Executing function {function_name} with args: {current_tool_call["function"]["arguments"]}")
+                                self.logger.debug(f"Executing function {function_name} with args: {current_tool_call['function']['arguments']}")
 
                                 # Regular function - execute progressively
                                 function_call = FunctionCall(


### PR DESCRIPTION
Fixed unmatched brackets in f-string by changing double quotes to single quotes in debug logging statement at arshai/llms/openai.py:782.