### PR TITLE
feat: add Phoenix-compatible span kind support to observability

### DIFF
--- a/arshai/observability/core.py
+++ b/arshai/observability/core.py
@@ -137,6 +137,8 @@ class ObservabilityManager:
             "llm.provider": provider,
             "llm.model_name": model,  # Renamed to match OpenInference
             "llm.method": method_name,
+            # Phoenix-specific attributes
+            "openinference.span.kind": self.config.kind.value if hasattr(self.config.kind, 'value') else self.config.kind, #https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing/instrument-python
         }
         
         # Add system if provided
@@ -224,6 +226,7 @@ class ObservabilityManager:
             "llm.model_name": model,  # Renamed to match OpenInference
             "llm.method": method_name,
             "llm.streaming": True,
+            "openinference.span.kind": self.config.kind.value if hasattr(self.config.kind, 'value') else self.config.kind
         }
         
         # Add system if provided


### PR DESCRIPTION
- Add SpanKind enum with Phoenix-compatible span types (CHAIN, LLM, TOOL, RETRIEVER, EMBEDDING, AGENT, RERANKER, GUARDRAIL, EVALUATOR)
- Add kind field to ObservabilityConfig with validation
- Add openinference.span.kind attribute to trace spans
- Support ARSHAI_SPAN_KIND environment variable for configuration
- Improve Phoenix integration compatibility
