### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/arshai/core/interfaces/illm.py
+++ b/arshai/core/interfaces/illm.py
@@ -41,6 +41,14 @@ class ILLMInput(IDTO):
     background_tasks: Dict[str, Callable] = Field(default={}, description="list of background tasks for fire-and-forget execution")
     structure_type: Type[T] = Field(default=None, description="Output response")
     max_turns: int = Field(default=10, description="Times that llm can call tools")
+    extra_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description=(
+            "Per-call HTTP headers to forward to the underlying gateway/provider. "
+            "Useful for request-scoped identity (e.g. X-Auth-User), trace IDs, or tenant tokens. "
+            "Merged on top of any default_headers configured on the client; only set when needed."
+        ),
+    )
 
     @model_validator(mode='before')
     @classmethod

--- a/arshai/llms/ai_gateway.py
+++ b/arshai/llms/ai_gateway.py
@@ -629,6 +629,8 @@ class AIGatewayLLM(BaseLLMClient):
         messages = self._create_openai_messages(input)
 
         kwargs = self._build_sampling_kwargs(messages)
+        if input.extra_headers:
+            kwargs["extra_headers"] = input.extra_headers
 
         if input.structure_type:
             structure_function = self._create_structure_function_openai(input.structure_type)
@@ -681,6 +683,8 @@ class AIGatewayLLM(BaseLLMClient):
                 start_time = time.time()
 
                 kwargs = self._build_sampling_kwargs(messages, tools=openai_tools if openai_tools else None)
+                if input.extra_headers:
+                    kwargs["extra_headers"] = input.extra_headers
 
                 response = self._client.chat.completions.create(**kwargs)
                 self.logger.info(f"Response time: {time.time() - start_time:.2f}s")
@@ -753,6 +757,8 @@ class AIGatewayLLM(BaseLLMClient):
         messages = self._create_openai_messages(input)
 
         kwargs = self._build_sampling_kwargs(messages, stream=True)
+        if input.extra_headers:
+            kwargs["extra_headers"] = input.extra_headers
 
         if input.structure_type:
             structure_function = self._create_structure_function_openai(input.structure_type)
@@ -838,6 +844,8 @@ class AIGatewayLLM(BaseLLMClient):
 
             try:
                 kwargs = self._build_sampling_kwargs(messages, tools=openai_tools if openai_tools else None, stream=True)
+                if input.extra_headers:
+                    kwargs["extra_headers"] = input.extra_headers
 
                 streaming_state = StreamingExecutionState()
                 collected_text = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "arshai"
-version = "1.11.0"
+version = "1.12.0"
 description = "A powerful agent framework for building conversational AI systems"
 authors = ["Nima Nazarian <nimunzn@gmail.com>"]
 readme = "README.md"

--- a/tests/unit/llms/test_ai_gateway_extra_headers.py
+++ b/tests/unit/llms/test_ai_gateway_extra_headers.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for per-call extra_headers forwarding in AIGatewayLLM.
+
+These tests verify that ILLMInput.extra_headers is forwarded to the underlying
+OpenAI client's chat.completions.create() call so that gateways can read
+request-scoped identity headers (e.g. X-Auth-User).
+
+Mocks the OpenAI client; no network or credentials required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from arshai.core.interfaces.illm import ILLMInput
+from arshai.llms.ai_gateway import AIGatewayConfig, AIGatewayLLM
+
+
+def _build_client_with_mock(monkeypatch, capture: dict) -> AIGatewayLLM:
+    """Construct AIGatewayLLM with its OpenAI client replaced by a capturing mock."""
+
+    config = AIGatewayConfig(
+        base_url="https://gateway.example.test/v1",
+        gateway_token="test-token",
+        model="test-model",
+        temperature=0.0,
+    )
+
+    # Bypass the real _initialize_client so we don't open a network client.
+    monkeypatch.setattr(
+        AIGatewayLLM,
+        "_initialize_client",
+        lambda self: MagicMock(),
+    )
+
+    llm = AIGatewayLLM(config)
+
+    fake_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=None))],
+        usage=SimpleNamespace(
+            prompt_tokens=1,
+            completion_tokens=1,
+            total_tokens=2,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        ),
+        id="resp-1",
+    )
+
+    def fake_create(**kwargs):
+        capture["kwargs"] = kwargs
+        return fake_response
+
+    llm._client.chat.completions.create = fake_create
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_chat_simple_forwards_extra_headers(monkeypatch):
+    capture: dict = {}
+    llm = _build_client_with_mock(monkeypatch, capture)
+
+    await llm.chat(
+        ILLMInput(
+            system_prompt="sys",
+            user_message="hi",
+            extra_headers={"X-Auth-User": "abc-base64", "X-Trace-Id": "t-1"},
+        )
+    )
+
+    assert "kwargs" in capture, "OpenAI client was not invoked"
+    assert capture["kwargs"].get("extra_headers") == {
+        "X-Auth-User": "abc-base64",
+        "X-Trace-Id": "t-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_chat_simple_omits_extra_headers_when_unset(monkeypatch):
+    capture: dict = {}
+    llm = _build_client_with_mock(monkeypatch, capture)
+
+    await llm.chat(ILLMInput(system_prompt="sys", user_message="hi"))
+
+    assert "kwargs" in capture
+    # Absent rather than None — we never want to pass an explicit None to the SDK.
+    assert "extra_headers" not in capture["kwargs"]
+
+
+@pytest.mark.asyncio
+async def test_stream_simple_forwards_extra_headers(monkeypatch):
+    capture: dict = {}
+    llm = _build_client_with_mock(monkeypatch, capture)
+
+    # Replace create() with a generator-returning callable to model streaming.
+    def fake_create(**kwargs):
+        capture["kwargs"] = kwargs
+        # Return an empty iterable; _stream_simple tolerates that and yields a final usage row.
+        return iter([])
+
+    llm._client.chat.completions.create = fake_create
+
+    async for _ in llm.stream(
+        ILLMInput(
+            system_prompt="sys",
+            user_message="hi",
+            extra_headers={"X-Auth-User": "stream-user"},
+        )
+    ):
+        pass
+
+    assert capture["kwargs"].get("extra_headers") == {"X-Auth-User": "stream-user"}
+    assert capture["kwargs"].get("stream") is True


### PR DESCRIPTION
- Added extra_headers field to ILLMInput for per-call HTTP headers.
- Updated AIGatewayLLM to forward extra_headers to the OpenAI client.
- Added unit tests for extra_headers functionality in AIGatewayLLM.